### PR TITLE
[DFS] BOJ-1987: 알파벳

### DIFF
--- a/ji-soo708/boj-1987.py
+++ b/ji-soo708/boj-1987.py
@@ -1,0 +1,24 @@
+# boj-1987: 알파벳
+# 상하좌우 이동, 같은 알파벳 적힌 칸으로는 지날 수 없음
+# 최대한 몇 칸 지날 수 있는지
+import sys
+
+input = sys.stdin.readline
+r,c = map(int, input().split())
+keyboard = [list(input().rstrip()) for _ in range(r)]
+dy,dx = [-1,1,0,0],[0,0,-1,1]
+key = [keyboard[0][0]]
+ans = 0
+
+def dfs(y,x,cnt):
+    global ans
+    ans = max(ans, cnt)
+    for d in range(4):
+        ny,nx = y+dy[d],x+dx[d]
+        if 0<=ny<r and 0<=nx<c and not keyboard[ny][nx] in key:
+            key.append(keyboard[ny][nx])
+            dfs(ny,nx,cnt+1)
+            key.remove(keyboard[ny][nx])
+
+dfs(0,0,1)
+print(ans)

--- a/ji-soo708/boj-1987.py
+++ b/ji-soo708/boj-1987.py
@@ -7,7 +7,7 @@ input = sys.stdin.readline
 r,c = map(int, input().split())
 keyboard = [list(input().rstrip()) for _ in range(r)]
 dy,dx = [-1,1,0,0],[0,0,-1,1]
-key = [keyboard[0][0]]
+key = set(keyboard[0][0])
 ans = 0
 
 def dfs(y,x,cnt):
@@ -16,7 +16,7 @@ def dfs(y,x,cnt):
     for d in range(4):
         ny,nx = y+dy[d],x+dx[d]
         if 0<=ny<r and 0<=nx<c and not keyboard[ny][nx] in key:
-            key.append(keyboard[ny][nx])
+            key.add(keyboard[ny][nx])
             dfs(ny,nx,cnt+1)
             key.remove(keyboard[ny][nx])
 


### PR DESCRIPTION
### 📝 문제: [백준] 알파벳
### 📎 유형: DFS
## ✏️ 접근 방식
1. 상하좌우로 이동하면서 최대한 몇 칸 이동하는지 체크
- DFS를 통해 조건(이미 지난 알파벳이 아니라면)에 맞는 칸으로 최대한 이동
2. 이미 지난 알파벳은 기록해야 하므로 `set`을 이용해 처리
- list는 해당 원소가 존재하는지 확인하는데 `O(n)`
- **set은 해시 구조로 해당 원소가 존재하는지 확인하는데 `O(1)`**
<br/>

## 🤔 개선사항
- 처음 풀 때 이미 지난 알파벳은 리스트를 통해 관리했는데 이렇게 하면 시간초과가 난다. 지금 문제에서는 굳이 list를 사용할 필요가 없는데 이런 경우를 잘 구별해서 풀어야겠다.
  
