### PR TITLE
[Two-Pointer] BOJ-1644: 소수의 연속합

### DIFF
--- a/ji-soo708/boj-1644.py
+++ b/ji-soo708/boj-1644.py
@@ -1,0 +1,37 @@
+# boj-1644: 소수의 연속합
+# 하나 이상의 연속된 소수의 합으로 나타낼 수 있는 자연수들이 있음
+# 연속된 소수의 합으로 나타낼 수 있는 경우의 수 구하기
+import sys
+
+input = sys.stdin.readline
+n = int(input())
+
+def prime_numbers(n):
+    sieve = [True] * (n + 1)
+    sieve[0] = sieve[1] = False
+    for i in range(2, int(n**0.5) + 1):
+        if sieve[i]:
+            for j in range(i * i, n + 1, i):
+                sieve[j] = False
+    return [i for i in range(2, n + 1) if sieve[i]]
+
+# 소수 리스트
+primes = prime_numbers(n)
+
+s, e = 0, 0
+cnt = 0
+current_sum = 0
+
+while True:
+    if current_sum >= n:
+        if current_sum == n:
+            cnt += 1
+        current_sum -= primes[s]
+        s += 1
+    elif e == len(primes):
+        break
+    else:
+        current_sum += primes[e]
+        e += 1
+
+print(cnt)


### PR DESCRIPTION
### 📝 문제: [백준] 소수의 연속합
### 📎 유형: 투포인터
## ✏️ 접근 방식
1. 시간복잡도를 위해 소수 구하는 함수는 에라토스테네스의 체로 구현
2. s,e로 연속된 소수의 구간을 나타냄
3. cur_sum이 n 이상이면 합을 줄이기 위해 s를 증가하고, 같다면 경우의 수 하나 추가
4. n 미만이면, 더 많은 소수를 추가하기 위해 e를 증가

<br/>

## 🤔 개선사항
- 어렵다어려워
  
